### PR TITLE
Fix wrong lines in namedays.json

### DIFF
--- a/src/namedays.json
+++ b/src/namedays.json
@@ -621,7 +621,6 @@
 			"Bendegúz",
 			"Gália"
 		],
-		[],
 		[
 			"Mihály",
 			"Győző"
@@ -1019,7 +1018,8 @@
 			"Jakab"
 		],
 		[
-			"PannaAnna",
+			"Panna",
+			"Anna",
 			"Anikó",
 			"Joakim"
 		],


### PR DESCRIPTION
- 8th May has an [] which means all the namedays in May are shifted +1 day.
- Also 26th July has "PannaAnna" mistakenly.